### PR TITLE
7507. 올림픽 경기

### DIFF
--- a/Algorithm/SANGMIN/7507.py
+++ b/Algorithm/SANGMIN/7507.py
@@ -1,0 +1,25 @@
+'''
+https://www.acmicpc.net/problem/7507
+올림픽 경기
+[풀이]
+1. 날짜 순으로 정렬 그리고 끝나는 시간으로 정렬한다.
+2. 내가 보고 있는 프로그램이 다음에 위치하는 프로그램과 겹칠 때
+=> 내가 보고 있는 프로그램이 먼저 끝난다(정렬을 그렇게 했으니까)
+=> 이후에 프로그램을 하나 더 볼 가능성이 높다
+=> 따라서 그대로 pass
+3. 내가 보고 있는 프로그램이 다음에 위치하는 프로그램보다 먼저 끝난다
+=> 볼 수 있는 프로그램 수를 하나 더 센다.
+'''
+import sys
+input = sys.stdin.readline
+n = int(input())
+for i in range(n):
+    m = int(input())
+    games = sorted([list(map(int, input().split())) for _ in range(m)], key = lambda x : (x[0], x[2]))
+    max_games = 0
+    cur_day = cur_ed = 0
+    for day, st, ed in games:
+        if cur_ed <= st or cur_day != day:
+            max_games += 1
+            cur_day, cur_ed = day, ed
+    print(f"Scenario #{i+1}:\n{max_games}\n")


### PR DESCRIPTION
시간초과만 10번 났다. 이유는 sys.readline 대신 input을 사용했기 때문. 총 입력이 한 테스트 케이스당 최대 5만이기 때문에 이렇게 입력이 많을 경우에는 readline을 사용해야 한다고 한다. 백준을 잘 안풀다보니 몰랐다. 애꿏은 코드만 건드리다 오래걸렸다.

input보다 sys.readline이 더 빠른이유는 [여기](https://stackoverflow.com/questions/22623528/sys-stdin-readline-and-input-which-one-is-faster-when-reading-lines-of-inpu)
readline은 개행문자도 읽기 때문에 strip도 필수라고 한다.